### PR TITLE
Fix istringstream read for readlines

### DIFF
--- a/session03/readlines.cc
+++ b/session03/readlines.cc
@@ -1,18 +1,20 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 using namespace std;
 
 int main() {
-    ifstream f("test.txt");
-    char buffer[4096]; // make a buffer definitely big enough to hold a line
-		char name[20];
-		double mass;
-		double radius;
+  ifstream f("test.txt");
+  char buffer[4096];  // make a buffer definitely big enough to hold a line
+  char name[20];
+  double mass;
+  double radius;
 
-    while (f.getline(buffer, sizeof(buffer))) { // if there is a line
-      istringstream line(buffer);
-			line >> name >> mass >> radius;
-			cout  << "name=" << name << " mass=" << mass << " radius=" << radius << '\n';
+  while (f.getline(buffer, sizeof(buffer))) {  // if there is a line
+    istringstream line(buffer);
+    if (line >> name >> mass >> radius) { // Check that reads succeeded
+      cout << "name=" << name << " mass=" << mass << " radius=" << radius
+           << '\n';
     }
+  }
 }


### PR DESCRIPTION
When using operator>> on a istringstream, there is a chance that it will
silently fail if the contents of the buffer have all already been read.
This is not a major issue in most scenarios. However, in a situation like
this, the while loop will read all of the lines in, get to the last
line, and then (I believe, I'm not 100% sure on this) read the EOF but
still continue into the loop. As a result, using operator>> with 'line'
during the last iteration will fail and the contents of 'name', 'mass',
and 'radius' will stay the same. Essentially, without the if-statement
the last line will get printed twice. Since this code is used as an
example for the robosim individual assignment, this is important to fix
before it gets used again.